### PR TITLE
Bugs/fix email confirmation

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,9 @@ class SessionsController < ApplicationController
 
   def create
     @user = User.find_by(email: params[:session][:email].downcase)
-    if @user && @user.authenticate(params[:session][:password])
+    if @user &&
+       @user.authenticate(params[:session][:password]) &&
+       @user.email_confirmed
       log_in @user
       redirect_to @user
     else

--- a/app/controllers/user_confirmation_controller.rb
+++ b/app/controllers/user_confirmation_controller.rb
@@ -1,9 +1,6 @@
 class UserConfirmationController < ApplicationController
   def show
-  end
-
-  def update
-    user = User.find_by_confirm_token(params[:id])
+    user = User.find_by(confirm_token: params[:id])
     if user
       user.email_activate
       flash[:success] = "Welcome to Blocitoff!"

--- a/app/views/user_mailer/registration_confirmation.html.erb
+++ b/app/views/user_mailer/registration_confirmation.html.erb
@@ -1,4 +1,4 @@
 <h1>Hiya <%= @user.name %></h1>,
 
 <p>Thanks for registering! To confirm your account, please click the link below.</p>
-<%= submit_confirmation_url(@user.confirm_token) %>
+<%= link_to "Confirm my account", submit_confirmation_url(@user.confirm_token) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,7 @@ Rails.application.routes.draw do
   post   "sign_in"   => "sessions#create"
   delete "sign_out"  => "sessions#destroy"
 
-  resources :user_confirmation, only:   [:update], as: "submit_confirmation"
-  resources :user_confirmation, only:   [:show]
+  resources :user_confirmation, only:   [:show], as: "submit_confirmation"
   resources :users,             except: [:new]
   resources :password_resets,   only:   [:new, :create, :edit, :update]
 


### PR DESCRIPTION
Hey @Enriikke. There was a nasty oversight on the email confirmation feature. Basically it didn't confirm emails :worried:.

The `User`'s `email_activate` method was being called from `user_confirmation_controller#update` but that doesn't work. The generated link takes us directly to `user_confirmation_controller#show`. I had the route defined as `PATCH` but clicking the link in the email only produces the `GET` request (even if I specify the method as PUT or PATCH). Looking at Devise, it **seems** like this logic happens in the `#show` method from a `GET` request, not `PUT` or `PATCH`.

Is this right? It seems un-CRUD-y; like the updating of our user's `email_confirmed` attribute should happen from `#update`, not `#show`.

This didn't come up because I was ALSO not checking if a user's email is activated before logging in. 
