### PR TITLE
Tasks/interactor specs

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < AuthenticatedController
   end
 
   def create
-    result = CreateUser.call(user: @user, user_params: user_params)
+    result = CreateUser.call(user_params: user_params)
 
     if result.success?
       flash[:notice] = "Thanks! Please check your email to complete sign up"

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -14,5 +14,15 @@ FactoryGirl.define do
     password "helloworld"
     password_confirmation "helloworld"
     email_confirmed false
+
+    after(:create) do |user|
+      user.confirm_token = SecureRandom.urlsafe_base64.to_s
+    end
+    after(:create) do |user|
+      user.confirm_digest = Encryptor.digest_token(user.confirm_token)
+    end
+    after(:create) do |user|
+      EncryptPassword.call(user: user)
+    end
   end
 end

--- a/spec/interactors/create_user_session_spec.rb
+++ b/spec/interactors/create_user_session_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe CreateUserSession do
 
   let(:user) { create(:unconfirmed_user) }
 
-  let(:interactor_context) do
-    Interactor::Context.new(errors: :val, user: user)
-  end
-
   let(:authenticate_user) { double("authenticate_user") }
   let(:login_user) { double("login_user") }
 
@@ -27,12 +23,12 @@ RSpec.describe CreateUserSession do
   describe ".call" do
     it "calls the AuthenticateUser interactor" do
       expect(authenticate_user).to receive(:run!)
-      subject.call(interactor_context)
+      subject.call
     end
 
     it "calls the LoginUser interactor" do
       expect(login_user).to receive(:run!)
-      subject.call(interactor_context)
+      subject.call
     end
   end
 end

--- a/spec/interactors/create_user_session_spec.rb
+++ b/spec/interactors/create_user_session_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe CreateUserSession do
+  subject { described_class }
+
+  let(:user) { create(:unconfirmed_user) }
+
+  let(:interactor_context) do
+    Interactor::Context.new(errors: :val, user: user)
+  end
+
+  let(:authenticate_user) { double("authenticate_user") }
+  let(:login_user) { double("login_user") }
+
+  before(:example) do
+    allow(AuthenticateUser).to receive(:new).and_return(authenticate_user)
+    allow(authenticate_user).to receive(:run!)
+    allow(authenticate_user).to receive(:run)
+    allow(authenticate_user).to receive(:context)
+
+    allow(LoginUser).to receive(:new).and_return(login_user)
+    allow(login_user).to receive(:run!)
+    allow(login_user).to receive(:run)
+    allow(login_user).to receive(:context)
+  end
+
+  describe ".call" do
+    it "calls the AuthenticateUser interactor" do
+      expect(authenticate_user).to receive(:run!)
+      subject.call(interactor_context)
+    end
+
+    it "calls the LoginUser interactor" do
+      expect(login_user).to receive(:run!)
+      subject.call(interactor_context)
+    end
+  end
+end

--- a/spec/interactors/create_user_session_spec.rb
+++ b/spec/interactors/create_user_session_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe CreateUserSession do
   subject { described_class }
 
-  let(:user) { create(:unconfirmed_user) }
-
   let(:authenticate_user) { double("authenticate_user") }
   let(:login_user) { double("login_user") }
 

--- a/spec/interactors/create_user_spec.rb
+++ b/spec/interactors/create_user_spec.rb
@@ -3,23 +3,10 @@ require "rails_helper"
 RSpec.describe CreateUser do
   subject { described_class }
 
-  # let(:interactors)
-  # {[
-  #   { class: MakeNewUser, double: double("make_new_user") },
-  #   { class: EncryptPassword, double: double("encrypt_password") },
-  #   { class: CreateConfirmationToken, double: double("create_confirmation_token") },
-  #   { class: SendNewUserConfirmation, double: double("send_new_user_confirmation") }
-  # ]}
   let(:user) { create(:unconfirmed_user) }
 
-  let(:user_params) do
-    {:user =>
-      { name: user.name,
-        email: user.email,
-        password: user.password,
-        password_confirmation: user.password_confirmation
-      }
-    }
+  let(:interactor_context) do
+    Interactor::Context.new(errors: :val, user: user)
   end
 
   let(:make_new_user) { double("make_new_user") }
@@ -28,26 +15,48 @@ RSpec.describe CreateUser do
   let(:send_new_user_confirmation) { double("send_new_user_confirmation") }
 
   before(:example) do
-    # interactors.each do |interactor|
-    #   allow(interactor.fetch(:class)).to receive(:new).and_return(interactor.fetch(:double))
-    # end
-
     allow(MakeNewUser).to receive(:new).and_return(make_new_user)
     allow(make_new_user).to receive(:run!)
+    allow(make_new_user).to receive(:run)
     allow(make_new_user).to receive(:context)
+
+    allow(EncryptPassword).to receive(:new).and_return(encrypt_password)
+    allow(encrypt_password).to receive(:run!)
+    allow(encrypt_password).to receive(:run)
+    allow(encrypt_password).to receive(:context)
+
+    allow(CreateConfirmationToken).to receive(:new).
+      and_return(create_confirmation_token)
+    allow(create_confirmation_token).to receive(:run!)
+    allow(create_confirmation_token).to receive(:run)
+    allow(create_confirmation_token).to receive(:context)
+
+    allow(SendNewUserConfirmation).to receive(:new).
+      and_return(send_new_user_confirmation)
+    allow(send_new_user_confirmation).to receive(:run!)
+    allow(send_new_user_confirmation).to receive(:run)
+    allow(send_new_user_confirmation).to receive(:context)
   end
 
   describe ".call" do
-    # interactors.each do |interactor|
-    #   it "calls the #{interactor.fetch(:class).name} interactor" do
-    #     expect(interactor.fetch(:double)).to receive(:run!)
-    #     subject.call
-    #   end
-    # end
-
     it "calls the MakeNewUser interactor" do
-      expect(make_new_user).to receive(:run!).with(user_params)
-      subject.call
+      expect(make_new_user).to receive(:run!)
+      subject.call(interactor_context)
+    end
+
+    it "calls the EncryptPassword interactor" do
+      expect(encrypt_password).to receive(:run!)
+      subject.call(interactor_context)
+    end
+
+    it "calls the CreateConfirmationToken interactor" do
+      expect(create_confirmation_token).to receive(:run!)
+      subject.call(interactor_context)
+    end
+
+    it "calls the SendNewUserConfirmation interactor" do
+      expect(send_new_user_confirmation).to receive(:run!)
+      subject.call(interactor_context)
     end
   end
 end

--- a/spec/interactors/create_user_spec.rb
+++ b/spec/interactors/create_user_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe CreateUser do
+  subject { described_class }
+
+  # let(:interactors)
+  # {[
+  #   { class: MakeNewUser, double: double("make_new_user") },
+  #   { class: EncryptPassword, double: double("encrypt_password") },
+  #   { class: CreateConfirmationToken, double: double("create_confirmation_token") },
+  #   { class: SendNewUserConfirmation, double: double("send_new_user_confirmation") }
+  # ]}
+  let(:user) { create(:unconfirmed_user) }
+
+  let(:user_params) do
+    {:user =>
+      { name: user.name,
+        email: user.email,
+        password: user.password,
+        password_confirmation: user.password_confirmation
+      }
+    }
+  end
+
+  let(:make_new_user) { double("make_new_user") }
+  let(:encrypt_password) { double("encrypt_password") }
+  let(:create_confirmation_token) { double("create_confirmation_token") }
+  let(:send_new_user_confirmation) { double("send_new_user_confirmation") }
+
+  before(:example) do
+    # interactors.each do |interactor|
+    #   allow(interactor.fetch(:class)).to receive(:new).and_return(interactor.fetch(:double))
+    # end
+
+    allow(MakeNewUser).to receive(:new).and_return(make_new_user)
+    allow(make_new_user).to receive(:run!)
+    allow(make_new_user).to receive(:context)
+  end
+
+  describe ".call" do
+    # interactors.each do |interactor|
+    #   it "calls the #{interactor.fetch(:class).name} interactor" do
+    #     expect(interactor.fetch(:double)).to receive(:run!)
+    #     subject.call
+    #   end
+    # end
+
+    it "calls the MakeNewUser interactor" do
+      expect(make_new_user).to receive(:run!).with(user_params)
+      subject.call
+    end
+  end
+end

--- a/spec/interactors/request_password_reset_token_spec.rb
+++ b/spec/interactors/request_password_reset_token_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe RequestPasswordResetToken do
+  subject { described_class }
+
+  let(:user) { create(:unconfirmed_user) }
+
+  let(:interactor_context) do
+    Interactor::Context.new(errors: :val, user: user)
+  end
+
+  let(:find_password_reset_user) { double("find_password_reset_user") }
+  let(:create_password_reset_token) { double("create_password_reset_token") }
+  let(:send_password_reset_email) { double("send_password_reset_email") }
+
+  before(:example) do
+    allow(FindPasswordResetUser).to receive(:new).
+      and_return(find_password_reset_user)
+    allow(find_password_reset_user).to receive(:run!)
+    allow(find_password_reset_user).to receive(:run)
+    allow(find_password_reset_user).to receive(:context)
+
+    allow(CreatePasswordResetToken).to receive(:new).
+      and_return(create_password_reset_token)
+    allow(create_password_reset_token).to receive(:run!)
+    allow(create_password_reset_token).to receive(:run)
+    allow(create_password_reset_token).to receive(:context)
+
+    allow(SendPasswordResetEmail).to receive(:new).
+      and_return(send_password_reset_email)
+    allow(send_password_reset_email).to receive(:run!)
+    allow(send_password_reset_email).to receive(:run)
+    allow(send_password_reset_email).to receive(:context)
+  end
+
+  describe ".call" do
+    it "calls the FindPasswordResetUser interactor" do
+      expect(find_password_reset_user).to receive(:run!)
+      subject.call(interactor_context)
+    end
+
+    it "calls the CreatePasswordResetToken interactor" do
+      expect(create_password_reset_token).to receive(:run!)
+      subject.call(interactor_context)
+    end
+
+    it "calls the SendPasswordResetEmail interactor" do
+      expect(send_password_reset_email).to receive(:run!)
+      subject.call(interactor_context)
+    end
+  end
+end

--- a/spec/interactors/request_password_reset_token_spec.rb
+++ b/spec/interactors/request_password_reset_token_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe RequestPasswordResetToken do
 
   let(:user) { create(:unconfirmed_user) }
 
-  let(:interactor_context) do
-    Interactor::Context.new(errors: :val, user: user)
-  end
-
   let(:find_password_reset_user) { double("find_password_reset_user") }
   let(:create_password_reset_token) { double("create_password_reset_token") }
   let(:send_password_reset_email) { double("send_password_reset_email") }
@@ -36,17 +32,17 @@ RSpec.describe RequestPasswordResetToken do
   describe ".call" do
     it "calls the FindPasswordResetUser interactor" do
       expect(find_password_reset_user).to receive(:run!)
-      subject.call(interactor_context)
+      subject.call
     end
 
     it "calls the CreatePasswordResetToken interactor" do
       expect(create_password_reset_token).to receive(:run!)
-      subject.call(interactor_context)
+      subject.call
     end
 
     it "calls the SendPasswordResetEmail interactor" do
       expect(send_password_reset_email).to receive(:run!)
-      subject.call(interactor_context)
+      subject.call
     end
   end
 end

--- a/spec/interactors/request_password_reset_token_spec.rb
+++ b/spec/interactors/request_password_reset_token_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe RequestPasswordResetToken do
   subject { described_class }
 
-  let(:user) { create(:unconfirmed_user) }
-
   let(:find_password_reset_user) { double("find_password_reset_user") }
   let(:create_password_reset_token) { double("create_password_reset_token") }
   let(:send_password_reset_email) { double("send_password_reset_email") }

--- a/spec/interactors/reset_password_spec.rb
+++ b/spec/interactors/reset_password_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe ResetPassword do
 
   let(:user) { create(:unconfirmed_user) }
 
-  let(:interactor_context) do
-    Interactor::Context.new(errors: :val, user: user)
-  end
-
   let(:update_password) { double("update_password") }
   let(:login_user) { double("login_user") }
 
@@ -27,12 +23,12 @@ RSpec.describe ResetPassword do
   describe ".call" do
     it "calls the UpdatePassword interactor" do
       expect(update_password).to receive(:run!)
-      subject.call(interactor_context)
+      subject.call
     end
 
     it "calls the LoginUser interactor" do
       expect(login_user).to receive(:run!)
-      subject.call(interactor_context)
+      subject.call
     end
   end
 end

--- a/spec/interactors/reset_password_spec.rb
+++ b/spec/interactors/reset_password_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe ResetPassword do
   subject { described_class }
 
-  let(:user) { create(:unconfirmed_user) }
-
   let(:update_password) { double("update_password") }
   let(:login_user) { double("login_user") }
 

--- a/spec/interactors/reset_password_spec.rb
+++ b/spec/interactors/reset_password_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe ResetPassword do
+  subject { described_class }
+
+  let(:user) { create(:unconfirmed_user) }
+
+  let(:interactor_context) do
+    Interactor::Context.new(errors: :val, user: user)
+  end
+
+  let(:update_password) { double("update_password") }
+  let(:login_user) { double("login_user") }
+
+  before(:example) do
+    allow(UpdatePassword).to receive(:new).and_return(update_password)
+    allow(update_password).to receive(:run!)
+    allow(update_password).to receive(:run)
+    allow(update_password).to receive(:context)
+
+    allow(LoginUser).to receive(:new).and_return(login_user)
+    allow(login_user).to receive(:run!)
+    allow(login_user).to receive(:run)
+    allow(login_user).to receive(:context)
+  end
+
+  describe ".call" do
+    it "calls the UpdatePassword interactor" do
+      expect(update_password).to receive(:run!)
+      subject.call(interactor_context)
+    end
+
+    it "calls the LoginUser interactor" do
+      expect(login_user).to receive(:run!)
+      subject.call(interactor_context)
+    end
+  end
+end

--- a/spec/interactors/verify_password_reset_user_spec.rb
+++ b/spec/interactors/verify_password_reset_user_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe VerifyPasswordResetUser do
+  subject { described_class }
+
+  let(:user) { create(:unconfirmed_user) }
+
+  let(:interactor_context) do
+    Interactor::Context.new(errors: :val, user: user)
+  end
+
+  let(:find_password_reset_token) { double("find_password_reset_token") }
+
+  let(:check_password_reset_expiration) do
+    double("check_password_reset_expiration")
+  end
+
+  before(:example) do
+    allow(FindPasswordResetToken).to receive(:new).
+      and_return(find_password_reset_token)
+    allow(find_password_reset_token).to receive(:run!)
+    allow(find_password_reset_token).to receive(:run)
+    allow(find_password_reset_token).to receive(:context)
+
+    allow(CheckPasswordResetExpiration).to receive(:new).
+      and_return(check_password_reset_expiration)
+    allow(check_password_reset_expiration).to receive(:run!)
+    allow(check_password_reset_expiration).to receive(:run)
+    allow(check_password_reset_expiration).to receive(:context)
+  end
+
+  describe ".call" do
+    it "calls the FindPasswordResetToken interactor" do
+      expect(find_password_reset_token).to receive(:run!)
+      subject.call(interactor_context)
+    end
+
+    it "calls the CheckPasswordResetExpiration interactor" do
+      expect(check_password_reset_expiration).to receive(:run!)
+      subject.call(interactor_context)
+    end
+  end
+end

--- a/spec/interactors/verify_password_reset_user_spec.rb
+++ b/spec/interactors/verify_password_reset_user_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe VerifyPasswordResetUser do
 
   let(:user) { create(:unconfirmed_user) }
 
-  let(:interactor_context) do
-    Interactor::Context.new(errors: :val, user: user)
-  end
-
   let(:find_password_reset_token) { double("find_password_reset_token") }
 
   let(:check_password_reset_expiration) do
@@ -32,12 +28,12 @@ RSpec.describe VerifyPasswordResetUser do
   describe ".call" do
     it "calls the FindPasswordResetToken interactor" do
       expect(find_password_reset_token).to receive(:run!)
-      subject.call(interactor_context)
+      subject.call
     end
 
     it "calls the CheckPasswordResetExpiration interactor" do
       expect(check_password_reset_expiration).to receive(:run!)
-      subject.call(interactor_context)
+      subject.call
     end
   end
 end

--- a/spec/interactors/verify_password_reset_user_spec.rb
+++ b/spec/interactors/verify_password_reset_user_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe VerifyPasswordResetUser do
   subject { described_class }
 
-  let(:user) { create(:unconfirmed_user) }
-
   let(:find_password_reset_token) { double("find_password_reset_token") }
 
   let(:check_password_reset_expiration) do


### PR DESCRIPTION
Hey @Enriikke check out the specs for the `organizers`. They could all stand to be refactored with loops for each of the individual interactors but I wanted to get things working this way first. Note the 

```
allow(x).to receive(:run!)
allow(x).to receive(:run)
```

lines in each of the tests. This seams to be the way to do it as the gem defines `run` as --

```
 def run
   run!
 rescue Failure
 end
```

... and my specs don't pass if I don't allow both `run` and `run!`. Also, I have to call `CreateUser` with a new context in order for those tests to pass. The others work fine with just `call` and no parameters. I'll dig deeper but hints are appreciated :grin:
