### PR TITLE
replace user factories with new names

### DIFF
--- a/spec/features/user_creates_todo_spec.rb
+++ b/spec/features/user_creates_todo_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "User creates a todo" do
-  let(:user) { create(:user, email_confirmed: true) }
+  let(:user) { create(:confirmed_user) }
 
   scenario "Successfully" do
     visit root_path

--- a/spec/features/user_deletes_todo_spec.rb
+++ b/spec/features/user_deletes_todo_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "User deletes todo" do
-  let(:user) { create(:user, email_confirmed: true) }
+  let(:user) { create(:confirmed_user) }
 
   scenario "Successfully" do
     visit root_path

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "User signs in" do
-  let(:user) { create(:user, email_confirmed: true) }
+  let(:user) { create(:confirmed_user) }
 
   scenario "Successfully" do
     visit root_path

--- a/spec/features/user_visits_profile_spec.rb
+++ b/spec/features/user_visits_profile_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "User visits profile" do
-  let(:user) { create(:user, email_confirmed: true) }
+  let(:user) { create(:confirmed_user) }
 
   before do
     visit root_path

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  let(:user_static_email) { create(:user, email: "test@test.com") }
-  let(:user_invalid_email) { build(:user, email: "xxx") }
+  let(:user_static_email)  { create(:confirmed_user, email: "test@test.com") }
+  let(:user_invalid_email) { build(:unconfirmed_user, email: "xxx") }
 
   describe "validations" do
     it "rejects an invalid email address" do
@@ -11,7 +11,7 @@ RSpec.describe User, type: :model do
 
     it "rejects a duplicate email address" do
       user_static_email
-      expect(build(:user, email: "test@test.com")).to_not be_valid
+      expect(build(:unconfirmed_user, email: "test@test.com")).to_not be_valid
     end
   end
 end


### PR DESCRIPTION
Just a little housekeeping. Somewhere along the line the `User` factories were renamed and a few tests broke. 

`user` becomes `unconfirmed_user` or `confirmed_user`
