### PR TITLE
Tasks/authenticate-user-spec

### DIFF
--- a/spec/interactors/authenticate_user_spec.rb
+++ b/spec/interactors/authenticate_user_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe AuthenticateUser do
+  describe ".call" do
+    let(:user)             { create(:confirmed_user) }
+    let(:unconfirmed_user) { create(:unconfirmed_user) }
+
+    context "when given valid credentials" do
+      subject(:context) do
+        described_class.call(email: user.email, password: user.password)
+      end
+
+      it "succeeds" do
+        expect(context).to be_a_success
+      end
+
+      it "provides the user" do
+        expect(context.user).to eq(user)
+      end
+    end
+
+    context "when given invalid user" do
+      subject(:context) do
+        described_class.call(email: "fake@bs.com", password: user.password)
+      end
+
+      it "fails" do
+        expect(context).to be_a_failure
+      end
+    end
+
+    context "when given invalid password" do
+      subject(:context) do
+        described_class.call(email: user.email, password: "nope")
+      end
+
+      it "fails" do
+        expect(context).to be_a_failure
+      end
+    end
+
+    context "when email not confirmed" do
+      subject(:context) do
+        described_class.call(email:    unconfirmed_user.email,
+                             password: unconfirmed_user.password)
+      end
+
+      it "fails" do
+        expect(context).to be_a_failure
+      end
+    end
+  end
+end

--- a/spec/interactors/authenticate_user_spec.rb
+++ b/spec/interactors/authenticate_user_spec.rb
@@ -6,47 +6,47 @@ RSpec.describe AuthenticateUser do
     let(:unconfirmed_user) { create(:unconfirmed_user) }
 
     context "when given valid credentials" do
-      subject(:context) do
+      subject do
         described_class.call(email: user.email, password: user.password)
       end
 
       it "succeeds" do
-        expect(context).to be_a_success
+        is_expected.to be_a_success
       end
 
       it "provides the user" do
-        expect(context.user).to eq(user)
+        expect(subject.user).to eq(user)
       end
     end
 
     context "when given invalid user" do
-      subject(:context) do
+      subject do
         described_class.call(email: "fake@bs.com", password: user.password)
       end
 
       it "fails" do
-        expect(context).to be_a_failure
+        is_expected.to be_a_failure
       end
     end
 
     context "when given invalid password" do
-      subject(:context) do
+      subject do
         described_class.call(email: user.email, password: "nope")
       end
 
       it "fails" do
-        expect(context).to be_a_failure
+        is_expected.to be_a_failure
       end
     end
 
     context "when email not confirmed" do
-      subject(:context) do
+      subject do
         described_class.call(email:    unconfirmed_user.email,
                              password: unconfirmed_user.password)
       end
 
       it "fails" do
-        expect(context).to be_a_failure
+        is_expected.to be_a_failure
       end
     end
   end


### PR DESCRIPTION
Hey @Enriikke! 

Taking a quick break from controller specs for a couple interactor unit tests. Have a look! Ideas on how to refactor this to be a little cleaner? I'm using Rspec's `subject` to tidy the `expect` statements much like Interactor's documentation describes. Thoughts?
