### PR TITLE
Tasks/create-password-reset-token-spec and find-password-reset-token-spec

### DIFF
--- a/app/interactors/create_password_reset_token.rb
+++ b/app/interactors/create_password_reset_token.rb
@@ -2,6 +2,7 @@ class CreatePasswordResetToken
   include Interactor
 
   def call
+    context.fail! unless context.user
     context.user.reset_token = generate_reset_token
     update_reset_attributes(context.enc, Time.zone.now)
   end

--- a/app/interactors/find_password_reset_token.rb
+++ b/app/interactors/find_password_reset_token.rb
@@ -2,9 +2,7 @@ class FindPasswordResetToken
   include Interactor
 
   def call
-    # context.fail! if user_nil? || incorrect_token?
-    context.fail!(errors: context.user.errors) unless
-      user_nil? || incorrect_token?
+    context.fail! if user_nil? || incorrect_token?
   end
 
   private

--- a/app/interactors/find_password_reset_token.rb
+++ b/app/interactors/find_password_reset_token.rb
@@ -2,6 +2,7 @@ class FindPasswordResetToken
   include Interactor
 
   def call
+    # context.fail! if user_nil? || incorrect_token?
     context.fail!(errors: context.user.errors) unless
       user_nil? || incorrect_token?
   end

--- a/spec/interactors/create_password_reset_token_spec.rb
+++ b/spec/interactors/create_password_reset_token_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe CreatePasswordResetToken do
+  describe ".call" do
+    let(:user) { create(:confirmed_user, reset_token: nil) }
+
+    context "when successful" do
+      subject do
+        described_class.call(user: user)
+      end
+
+      it "sets the user's reset token" do
+        expect(subject.user.reset_token).to eq(subject.raw)
+      end
+
+      it "sets the user's reset_digest" do
+        expect(subject.user.reset_digest).to eq(subject.enc)
+      end
+
+      it "sets the user's reset_sent_at" do
+        expect(subject.user.reset_sent_at).to be_an(ActiveSupport::TimeWithZone)
+      end
+    end
+
+    context "when there isn't a valid user" do
+      subject do
+        described_class.call(user: nil)
+      end
+
+      it "fails" do
+        is_expected.to be_a_failure
+      end
+    end
+  end
+end

--- a/spec/interactors/find_password_reset_token_spec.rb
+++ b/spec/interactors/find_password_reset_token_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe FindPasswordResetToken do
+  describe ".call" do
+    let(:user) { create(:confirmed_user, reset_token: nil, reset_digest: nil) }
+
+    before(:example) do
+      CreatePasswordResetToken.call(user: user)
+    end
+
+    context "when user and correct token provided" do
+      subject do
+        described_class.call(user: user, id: user.reset_token)
+      end
+
+      it "returns successfully" do
+        is_expected.to be_a_success
+      end
+    end
+
+    context "when user is nil" do
+      subject do
+        described_class.call(user: nil, id: user.reset_token)
+      end
+
+      it "fails" do
+        is_expected.to be_a_failure
+      end
+    end
+
+    context "when token is incorrect" do
+      subject do
+        described_class.call(user: user, id: "HastThouConsideredTheTetrapod")
+      end
+
+      it "fails" do
+        is_expected.to be_a_failure
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey @Enriikke, quick question below...

Also, I meant to do a separate PR for `find-password-reset-token-spec` but ... I did not :smile: 

They're related so I'll leave it here. Have a look though, those tests currently fail because I made a mistake in the `FindPasswordResetToken` interactor (I meant `if`, not `unless`. I added the correct logic, commented out).  Although that context fails, it' still passing to the next interactor in the `VerifyPasswordResetUser` organizer and that one is succeeding. So basically, even though it should have been broken, the feature has been working fine. As I've mentioned, the odds of this being a bug rather than user error seem low but am I mistaken on how this should be working?

EDIT: I think this has something to do with how I'm actually calling `VerifyPasswordResetUser` in the controller. I'm not really checking if it succeeds or not so it's very possible the whole `organizer` really IS failing. I guess, even if it fails, perhaps it retains it's `user` and therefor assigns `@user` properly even if everything else blew up? 

Here's the call in the controller --

```
def verify_password_reset_user
    @user = VerifyPasswordResetUser.call(
      user: User.find_by(email: params[:email]),
      id:   params[:id]).user
  end
```
