### PR TITLE
Tasks/update-password-spec

### DIFF
--- a/app/interactors/update_password.rb
+++ b/app/interactors/update_password.rb
@@ -3,17 +3,21 @@ class UpdatePassword
 
   def call
     context.fail!(errors: context.user.errors) unless password_update
+    hashed_password_update(context.user, context.user.password)
+    reset_digest_update
   end
 
   private
 
-  def password_update
-    context.user.update_attributes(context.user_params)
+  def reset_digest_update
     context.user.update_attribute(:reset_digest, nil)
-    update_hashed_password(context.user, context.user.password)
   end
 
-  def update_hashed_password(user, password)
+  def password_update
+    context.user.update(context.user_params)
+  end
+
+  def hashed_password_update(user, password)
     salt = Encryptor.generate_salt
     password_hash = Encryptor.digest_password(password, salt)
     user.update_attribute(:password_salt, salt)

--- a/spec/interactors/update_password_spec.rb
+++ b/spec/interactors/update_password_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe UpdatePassword do
       end
     end
 
-    context "when unsuccessful" do
+    context "when password confirmation does not match" do
       subject do
         described_class.call(user_params: user_params, user: user)
       end

--- a/spec/interactors/update_password_spec.rb
+++ b/spec/interactors/update_password_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe UpdatePassword do
+  describe ".call" do
+    let(:user) { create(:confirmed_user) }
+
+    let(:user_params) do
+      { password: "newpass", password_confirmation: "newpass" }
+    end
+
+    let(:salt) { Encryptor.generate_salt }
+
+    context "when successful" do
+      subject do
+        described_class.call(user_params: user_params, user: user)
+      end
+
+      it "succeeds" do
+        is_expected.to be_a_success
+      end
+
+      it "updates password_hash" do
+        expect(subject.user.password_hash).
+          to eq(Encryptor.digest_password(user_params[:password],
+                                          user.password_salt))
+      end
+
+      it "updates password_salt" do
+        orig_salt = user.password_salt
+        described_class.call(user_params: user_params, user: user)
+        new_salt = user.password_salt
+        expect(orig_salt).not_to eq(new_salt)
+      end
+
+      it "sets reset_digest to nil" do
+        expect(subject.user.reset_digest).to be_nil
+      end
+    end
+
+    context "when unsuccessful" do
+      subject do
+        described_class.call(user_params: user_params, user: user)
+      end
+
+      before do
+        user_params[:password_confirmation] = "TheseAreNotTheDroids..."
+      end
+
+      it "fails" do
+        is_expected.to be_a_failure
+      end
+    end
+  end
+end

--- a/spec/interactors/update_password_spec.rb
+++ b/spec/interactors/update_password_spec.rb
@@ -26,10 +26,7 @@ RSpec.describe UpdatePassword do
       end
 
       it "updates password_salt" do
-        orig_salt = user.password_salt
-        described_class.call(user_params: user_params, user: user)
-        new_salt = user.password_salt
-        expect(orig_salt).not_to eq(new_salt)
+        expect { subject }.to change { user.password_salt }
       end
 
       it "sets reset_digest to nil" do


### PR DESCRIPTION
Hey @Enriikke!  `update_password` would previously not fail when `password` and `password_confirmation` did not match. This fixes that issue and adds specs for the interactor.
